### PR TITLE
feat(infra): add S3 bucket configuration for frontend

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -50,7 +50,61 @@ resource "aws_dynamodb_table" "simple_table" {
   }
 }
 
+resource "aws_s3_bucket" "frontend_bucket" {
+  bucket = "shared-expenses-frontend-test-bucket"
+
+  tags = {
+    Name        = "frontend-bucket"
+    Environment = "dev"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "frontend_bucket_public" {
+  bucket = aws_s3_bucket.frontend_bucket.id
+
+  block_public_acls   = false
+  block_public_policy = false
+  ignore_public_acls  = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_policy" "frontend_bucket_policy" {
+  bucket = aws_s3_bucket.frontend_bucket.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = "*"
+        Action = [
+          "s3:GetObject"
+        ]
+        Resource = [
+          "${aws_s3_bucket.frontend_bucket.arn}/*"
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_s3_bucket_website_configuration" "frontend_bucket_website" {
+  bucket = aws_s3_bucket.frontend_bucket.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "error.html"
+  }
+}
+
 output "dynamodb_table_name" {
   description = "The name of the DynamoDB table created"
   value       = aws_dynamodb_table.simple_table.name
+}
+
+output "frontend_bucket_website_url" {
+  description = "URL del sitio web estático en S3 para el frontend"
+  value       = aws_s3_bucket_website_configuration.frontend_bucket_website.website_endpoint
 }


### PR DESCRIPTION
Introduced a new S3 bucket for the frontend with public access settings, a bucket policy allowing object retrieval, and website configuration for static hosting. Added output for the website URL.